### PR TITLE
Abstract out Block and Field Formatters into submodules.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -31,11 +31,11 @@ For link sharing statistics registration at http://addthis.com/ is required, but
 the module will work even without registration.
 
 -- INCLUDED MODULES --
-addthis - Provides the base API to integrate with AddThis. Also creates RenderElements,
+**addthis** - Provides the base API to integrate with AddThis. Also creates RenderElements,
 base Twig templates and global admin settings for AddThis. Does not provide any
 rendering functionality on its own.
-addthis_block - Provides a configurable block for displaying AddThis.
-addthis_fields - Provides two field formatters for AddThis to allow for rendering on
+**addthis_block** - Provides a configurable block for displaying AddThis.
+**addthis_fields** - Provides two field formatters for AddThis to allow for rendering on
 entities.
 
 -- CONFIGURATION --

--- a/README.txt
+++ b/README.txt
@@ -31,11 +31,11 @@ For link sharing statistics registration at http://addthis.com/ is required, but
 the module will work even without registration.
 
 -- INCLUDED MODULES --
-**addthis** - Provides the base API to integrate with AddThis. Also creates RenderElements,
+1. **addthis** - Provides the base API to integrate with AddThis. Also creates RenderElements,
 base Twig templates and global admin settings for AddThis. Does not provide any
 rendering functionality on its own.
-**addthis_block** - Provides a configurable block for displaying AddThis.
-**addthis_fields** - Provides two field formatters for AddThis to allow for rendering on
+2. **addthis_block** - Provides a configurable block for displaying AddThis.
+3. **addthis_fields** - Provides two field formatters for AddThis to allow for rendering on
 entities.
 
 -- CONFIGURATION --

--- a/README.txt
+++ b/README.txt
@@ -30,6 +30,14 @@ information.
 For link sharing statistics registration at http://addthis.com/ is required, but
 the module will work even without registration.
 
+-- INCLUDED MODULES --
+addthis - Provides the base API to integrate with AddThis. Also creates RenderElements,
+base Twig templates and global admin settings for AddThis. Does not provide any
+rendering functionality on its own.
+addthis_block - Provides a configurable block for displaying AddThis.
+addthis_fields - Provides two field formatters for AddThis to allow for rendering on
+entities.
+
 -- CONFIGURATION --
 
 Use the admin configuration page to configure settings and see http://drupal.org/node/1309922
@@ -42,7 +50,10 @@ and altering configuration on rendering.
 
 -- CONTACT --
 
-Current maintainers:
+Current D8 contributors
+* John Doyle (doylejd) - https://www.drupal.org/u/doylejd
+
+Current D7 maintainers:
 * Vesa Palmu (wesku) - http://drupal.org/user/75070
 * Jani Palsamäki (janip) - http://drupal.org/user/1356218
 * Matthias Glastra (matglas86) - http://drupal.org/user/573464

--- a/addthis.module
+++ b/addthis.module
@@ -24,8 +24,8 @@ function addthis_page_attachments(array &$page){
 
 // Include the widget js when we include on all but admin pages.
   //if (!path_is_admin(current_path()) && AddThis::getInstance()->getWidgetJsInclude() == AddThis::WIDGET_JS_INCLUDE_PAGE) {
-  $manager = \Drupal\addthis\Services\AddThisScriptManager::getInstance();
-  $manager->attachJsToElement($page);
+  //$manager = \Drupal\addthis\Services\AddThisScriptManager::getInstance();
+  //$manager->attachJsToElement($page);
   //}
 
 }

--- a/addthis.module
+++ b/addthis.module
@@ -20,14 +20,6 @@ function addthis_theme() {
  */
 function addthis_page_attachments(array &$page){
   $page['#attached']['library'][] = 'addthis/addthis.global';
-
-
-// Include the widget js when we include on all but admin pages.
-  //if (!path_is_admin(current_path()) && AddThis::getInstance()->getWidgetJsInclude() == AddThis::WIDGET_JS_INCLUDE_PAGE) {
-  //$manager = \Drupal\addthis\Services\AddThisScriptManager::getInstance();
-  //$manager->attachJsToElement($page);
-  //}
-
 }
 
 

--- a/addthis_block/addthis_block.info.yml
+++ b/addthis_block/addthis_block.info.yml
@@ -1,0 +1,11 @@
+name: AddThis Block
+description: Provides a configurable block to render AddThis elements.
+type: module
+package: Sharing
+core: 8.x
+
+dependencies:
+  - addthis
+
+
+

--- a/addthis_fields/addthis_fields.info.yml
+++ b/addthis_fields/addthis_fields.info.yml
@@ -1,0 +1,11 @@
+name: AddThis Fields
+description: Provides a basic field definitions for rendering AddThis.
+type: module
+package: Sharing
+core: 8.x
+
+dependencies:
+  - addthis
+
+
+

--- a/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicButtonFormatter.php
+++ b/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicButtonFormatter.php
@@ -1,16 +1,17 @@
 <?php
 /**
  * @file
- * Contains \Drupal\addthis\Plugin\Field\FieldFormatter\AddThisBasicButtonFormatter.
+ * Contains \Drupal\addthis_fields\Plugin\Field\FieldFormatter\AddThisBasicButtonFormatter.
  */
 
-namespace Drupal\addthis\Plugin\Field\FieldFormatter;
+namespace Drupal\addthis_fields\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\addthis\AddThis;
 use Drupal\addthis\Services\AddThisScriptManager;
+
 
 /**
  * Plugin implementation of the 'addthis_basic_button' formatter.
@@ -23,7 +24,7 @@ use Drupal\addthis\Services\AddThisScriptManager;
  *   }
  * )
  */
-class AddThisBasicButtonFormatter extends AddThisFormatter {
+class AddThisBasicButtonFormatter extends FormatterBase {
 
   /**
    * {@inheritdoc}

--- a/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicToolboxFormatter.php
+++ b/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicToolboxFormatter.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * @file
- * Contains \Drupal\addthis\Plugin\Field\FieldFormatter\AddThisBasicToolboxFormatter.
+ * Contains \Drupal\addthis_fields\Plugin\Field\FieldFormatter\AddThisBasicToolboxFormatter.
  */
 
-namespace Drupal\addthis\Plugin\Field\FieldFormatter;
+namespace Drupal\addthis_fields\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
@@ -23,7 +23,7 @@ use Drupal\addthis\Services\AddThisScriptManager;
  *   }
  * )
  */
-class AddThisBasicToolboxFormatter extends AddThisFormatter {
+class AddThisBasicToolboxFormatter extends FormatterBase {
 
   /**
    * {@inheritdoc}
@@ -121,7 +121,6 @@ class AddThisBasicToolboxFormatter extends AddThisFormatter {
     // Add the widget script.
     $script_manager = AddThisScriptManager::getInstance();
     $script_manager->attachJsToElement($element);
-
 
     $widget_settings = $this->getSettings();
 

--- a/js/addthis.js
+++ b/js/addthis.js
@@ -6,7 +6,7 @@
 (function ($, Drupal, drupalSettings) {
   Drupal.behaviors.addthis = {
     scriptLoaded: false,
-    attach: function(context) {
+    attach: function(context, settings) {
 
       // The addthis configuration is not loaded but the settings are passed
       // to do so.

--- a/src/AddThis.php
+++ b/src/AddThis.php
@@ -243,38 +243,6 @@ class AddThis {
     return $displays;
   }
 
-  /*
-   * Get markup for a given display type.
-   *
-   * When $options does not contain #entity, link to the current URL.
-   * When $options does not contain #display, use default settings.
-   */
-  public function getDisplayMarkup($display, $options = array()) {
-    $formatters = \Drupal::Service('plugin.manager.field.formatter')->getDefinitions();
 
-    if (!array_key_exists($display, $formatters)) {
-      return array();
-    }
-    // The display type exists. Now get it and get the markup.
-    $display_information = $formatters[$display];
-
-    // Theme function might only give a display name and
-    // render on default implementation.
-    if (!isset($options['#display']) ||
-      (isset($options['#display']['type']) && $options['#display']['type'] != $display)) {
-
-      $options['#display'] = isset($options['#display']) ? $options['#display'] : array();
-      $options['#display'] = array_merge($options['#display'], $display_information);
-      $options['#display']['type'] = $display;
-
-    }
-    
-
-    $markup = array(
-      '#display' => $options['#display'],
-    );
-
-    return $markup;
-  }
 
 }

--- a/src/Element/AddThisElement.php
+++ b/src/Element/AddThisElement.php
@@ -30,6 +30,12 @@ class AddThisElement extends RenderElement {
   }
 
 
+  /**
+   * Implements preRenderAddThisElement()
+   *  - Defines consistent markup for new render type of addthis_element.
+   * @param $element
+   * @return mixed
+   */
   public static function preRenderAddThisElement($element){
     if (!isset($element['#value'])) {
       $element['addthis_element'] = [

--- a/src/Element/AddThisWrapper.php
+++ b/src/Element/AddThisWrapper.php
@@ -30,19 +30,13 @@ class AddThisWrapper extends RenderElement {
   }
 
   /**
+   * Implements preRenderAddThisWrapper()
+   *   - Defines consistent markup for the addthis_wrapper render element.
    * @param $element
    * @return mixed
    */
   public static function preRenderAddThisWrapper($element){
     $output = '<' . $element['#tag'] . new Attribute($element['#attributes']) . '>';
-    $children = Element::children($element);
-
-//    if (count($children) > 0) {
-//      foreach ($children as $child) {
-//        $output .= render($element[$child]);
-//      }
-//    }
-
     $output .= '</' . $element['#tag'] . ">\n";
     $element['addthis_wrapper'] = [
       '#markup' => $output

--- a/templates/addthis-wrapper.html.twig
+++ b/templates/addthis-wrapper.html.twig
@@ -9,6 +9,4 @@
  */
 #}
 
-<div>
 {{ element }}
-</div>


### PR DESCRIPTION
- Abstracted out blocks and field formatters into their own modules. 
- Added configuration settings to block to match AddThisBasicToolbox for more flexibility.
- Remove global addition of addthis_widget. Place it into render functions of fields/blocks.
