### PR TITLE
Abstracted out BasicButton and BasicToolbox Forms/displays.

### DIFF
--- a/addthis.module
+++ b/addthis.module
@@ -18,12 +18,12 @@ function addthis_theme() {
  * @TODO Find another way to do this since it breaks aggregation.
  * @param array $page
  */
-function addthis_page_attachments(array &$page){
+function addthis_page_attachments(array &$page) {
   $page['#attached']['library'][] = 'addthis/addthis.global';
 }
 
 
-function addthis_library_info_alter(){
+function addthis_library_info_alter() {
 
 }
 
@@ -32,7 +32,8 @@ function addthis_library_info_alter(){
  * Implementation to retrieve formatters for a given type of field.
  */
 function _addthis_field_info_formatter_field_type($field_type = NULL) {
-  $formatters = \Drupal::Service('plugin.manager.field.formatter')->getDefinitions();
+  $formatters = \Drupal::Service('plugin.manager.field.formatter')
+    ->getDefinitions();
   foreach ($formatters as $key => $formatter) {
     if (!in_array((!isset($field_type) ? 'addthis' : $field_type), $formatter['field_types'])) {
       unset($formatters[$key]);
@@ -47,8 +48,7 @@ function _addthis_field_info_formatter_field_type($field_type = NULL) {
  * @param array $element
  * @param FormStateInterface $form_state
  */
-function addThisDisplayElementServicesValidate(array $element, FormStateInterface $form_state)
-{
+function addThisDisplayElementServicesValidate(array $element, FormStateInterface $form_state) {
   $bad = FALSE;
 
   $services = trim($element['#value']);

--- a/addthis.module
+++ b/addthis.module
@@ -42,3 +42,26 @@ function _addthis_field_info_formatter_field_type($field_type = NULL) {
 }
 
 
+/**
+ * Validation for services for BasicToolbox.
+ * @param array $element
+ * @param FormStateInterface $form_state
+ */
+function addThisDisplayElementServicesValidate(array $element, FormStateInterface $form_state)
+{
+  $bad = FALSE;
+
+  $services = trim($element['#value']);
+  $services = str_replace(' ', '', $services);
+
+  if (!preg_match('/^[a-z\_\,0-9]+$/', $services)) {
+    $bad = TRUE;
+  }
+  // @todo Validate the service names against AddThis.com. Give a notice when there are bad names.
+
+  // Return error.
+  if ($bad) {
+    form_error($element, t('The declared services are incorrect or nonexistent.'));
+  }
+}
+

--- a/addthis_block/src/Plugin/Block/AddThisBlock.php
+++ b/addthis_block/src/Plugin/Block/AddThisBlock.php
@@ -19,14 +19,12 @@ use Drupal\addthis\AddThis;
  *   category = @Translation("Blocks")
  * )
  */
-class AddThisBlock extends BlockBase
-{
+class AddThisBlock extends BlockBase {
 
   /**
    * {@inheritdoc}
    */
-  public function defaultConfiguration()
-  {
+  public function defaultConfiguration() {
     return array(
       'type' => 'addthis_disabled',
       'basic_toolbox' => array(
@@ -45,17 +43,26 @@ class AddThisBlock extends BlockBase
   /**
    * {@inheritdoc}
    */
-  function blockForm($form, FormStateInterface $form_state)
-  {
+  function blockForm($form, FormStateInterface $form_state) {
 
     // The list of formatters.
     $formatter_options = AddThis::getInstance()->getDisplayTypes();
     $settings = $this->getConfiguration();
 
     $type = $settings['type'];
-    $rebuild = $form_state->getValue(['settings', 'settings', 'addthis_settings', 'type']);
-    if( isset($rebuild) ){
-      $type = $form_state->getValue(['settings', 'settings', 'addthis_settings', 'type']);
+    $rebuild = $form_state->getValue([
+      'settings',
+      'settings',
+      'addthis_settings',
+      'type'
+    ]);
+    if (isset($rebuild)) {
+      $type = $form_state->getValue([
+        'settings',
+        'settings',
+        'addthis_settings',
+        'type'
+      ]);
     }
 
     $form['settings']['addthis_settings'] = array(
@@ -80,13 +87,17 @@ class AddThisBlock extends BlockBase
       '#prefix' => '<div id="addthis_type_settings"',
       '#suffix' => '</div>',
     );
-    if($type == 'addthis_basic_toolbox'){
-      $basicToolbox = AddThis::getInstance()->getBasicToolboxForm($this, $settings['basic_toolbox']);
+    if ($type == 'addthis_basic_toolbox') {
+      $basicToolbox = AddThis::getInstance()
+        ->getBasicToolboxForm($this, $settings['basic_toolbox']);
       $form['settings']['addthis_settings']['type_settings']['basic_toolbox'] = $basicToolbox;
     }
-    else if ($type == 'addthis_basic_button'){
-      $basicButton = AddThis::getInstance()->getBasicButtonForm($this, $settings['basic_button']);
-      $form['settings']['addthis_settings']['type_settings']['basic_button'] = $basicButton;
+    else {
+      if ($type == 'addthis_basic_button') {
+        $basicButton = AddThis::getInstance()
+          ->getBasicButtonForm($this, $settings['basic_button']);
+        $form['settings']['addthis_settings']['type_settings']['basic_button'] = $basicButton;
+      }
     }
 
 
@@ -99,37 +110,77 @@ class AddThisBlock extends BlockBase
    * @param FormStateInterface $form_state
    * @return mixed
    */
-  public function addthisAjaxCallback(array $form, FormStateInterface $form_state){
+  public function addthisAjaxCallback(array $form, FormStateInterface $form_state) {
     return $form['settings']['settings']['addthis_settings']['type_settings'];
   }
 
   /**
    * {@inheritdoc}
    */
-  public function blockSubmit($form, FormStateInterface $form_state)
-  {
-    $this->configuration['type'] = $form_state->getValue(['settings', 'addthis_settings', 'type']);
-    $this->configuration['basic_toolbox']['share_services'] = $form_state->getValue(['settings', 'addthis_settings', 'type_settings', 'basic_toolbox', 'share_services']);
-    $this->configuration['basic_toolbox']['buttons_size'] = $form_state->getValue(['settings', 'addthis_settings', 'type_settings', 'basic_toolbox', 'buttons_size']);
-    $this->configuration['basic_toolbox']['counter_orientation'] = $form_state->getValue(['settings', 'addthis_settings', 'type_settings', 'basic_toolbox', 'counter_orientation']);
-    $this->configuration['basic_toolbox']['extra_css'] = $form_state->getValue(['settings', 'addthis_settings', 'type_settings', 'basic_toolbox', 'extra_css']);
-    $this->configuration['basic_button']['button_size'] = $form_state->getValue(['settings', 'addthis_settings', 'type_settings', 'basic_button', 'button_size']);
-    $this->configuration['basic_button']['extra_css'] = $form_state->getValue(['settings', 'addthis_settings', 'type_settings', 'basic_button', 'extra_css']);
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    $this->configuration['type'] = $form_state->getValue([
+      'settings',
+      'addthis_settings',
+      'type'
+    ]);
+    $this->configuration['basic_toolbox']['share_services'] = $form_state->getValue([
+      'settings',
+      'addthis_settings',
+      'type_settings',
+      'basic_toolbox',
+      'share_services'
+    ]);
+    $this->configuration['basic_toolbox']['buttons_size'] = $form_state->getValue([
+      'settings',
+      'addthis_settings',
+      'type_settings',
+      'basic_toolbox',
+      'buttons_size'
+    ]);
+    $this->configuration['basic_toolbox']['counter_orientation'] = $form_state->getValue([
+      'settings',
+      'addthis_settings',
+      'type_settings',
+      'basic_toolbox',
+      'counter_orientation'
+    ]);
+    $this->configuration['basic_toolbox']['extra_css'] = $form_state->getValue([
+      'settings',
+      'addthis_settings',
+      'type_settings',
+      'basic_toolbox',
+      'extra_css'
+    ]);
+    $this->configuration['basic_button']['button_size'] = $form_state->getValue([
+      'settings',
+      'addthis_settings',
+      'type_settings',
+      'basic_button',
+      'button_size'
+    ]);
+    $this->configuration['basic_button']['extra_css'] = $form_state->getValue([
+      'settings',
+      'addthis_settings',
+      'type_settings',
+      'basic_button',
+      'extra_css'
+    ]);
 
   }
 
   /**
    * {@inheritdoc}
    */
-  public function build()
-  {
+  public function build() {
     $config = $this->configuration;
-    switch($config['type']){
+    switch ($config['type']) {
       case 'addthis_basic_button':
-        $markup = AddThis::getInstance()->getBasicButtonMarkup($config['basic_button']);
+        $markup = AddThis::getInstance()
+          ->getBasicButtonMarkup($config['basic_button']);
         break;
       case 'addthis_basic_toolbox':
-        $markup = AddThis::getInstance()->getBasicToolboxMarkup($config['basic_toolbox']);
+        $markup = AddThis::getInstance()
+          ->getBasicToolboxMarkup($config['basic_toolbox']);
         break;
       default:
         $markup = '';
@@ -141,7 +192,6 @@ class AddThisBlock extends BlockBase
     );
 
   }
-
 
 
 }

--- a/addthis_block/src/Plugin/Block/AddThisBlock.php
+++ b/addthis_block/src/Plugin/Block/AddThisBlock.php
@@ -148,7 +148,7 @@ class AddThisBlock extends BlockBase
     );
 
     $settings = $this->getConfiguration();
-    $elements = AddThis::getInstance()->getBasicToolboxForm($settings);
+    $elements = AddThis::getInstance()->getBasicToolboxForm($this, $settings);
 
     $form['settings']['addthis_settings'] += $elements;
 

--- a/addthis_block/src/Plugin/Block/AddThisBlock.php
+++ b/addthis_block/src/Plugin/Block/AddThisBlock.php
@@ -40,6 +40,7 @@ class AddThisBlock extends BlockBase
    */
   public function build()
   {
+
     $config = $this->configuration;
     $element = array(
       '#type' => 'addthis_wrapper',
@@ -57,6 +58,7 @@ class AddThisBlock extends BlockBase
     // Add the widget script.
     $script_manager = AddThisScriptManager::getInstance();
     $script_manager->attachJsToElement($element);
+
 
     $services = trim($config['share_services']);
     $services = str_replace(' ', '', $services);
@@ -132,7 +134,6 @@ class AddThisBlock extends BlockBase
     $element += $items;
 
     $markup = render($element);
-
     return array(
       '#markup' => $markup
     );
@@ -146,46 +147,11 @@ class AddThisBlock extends BlockBase
       '#title' => 'Display settings',
     );
 
+    $settings = $this->getConfiguration();
+    $elements = AddThis::getInstance()->getBasicToolboxForm($settings);
 
-    $form['settings']['addthis_settings']['share_services'] = array(
-      '#title' => t('Services'),
-      '#type' => 'textfield',
-      '#size' => 80,
-      '#default_value' => $this->configuration['share_services'],
-      '#required' => TRUE,
-      '#element_validate' => array($this, 'addThisDisplayElementServicesValidate'),
-      '#description' =>
-        t('Specify the names of the sharing services and seperate them with a , (comma). <a href="http://www.addthis.com/services/list" target="_blank">The names on this list are valid.</a>') .
-        t('Elements that are available but not ont the services list are (!services).',
-          array('!services' => 'bubble_style, pill_style, tweet, facebook_send, twitter_follow_native, google_plusone, stumbleupon_badge, counter_* (several supported services), linkedin_counter')
-        ),
-    );
-    $form['settings']['addthis_settings']['buttons_size'] = array(
-      '#title' => t('Buttons size'),
-      '#type' => 'select',
-      '#default_value' => $this->configuration['buttons_size'],
-      '#options' => array(
-        'addthis_16x16_style' => t('Small (16x16)'),
-        'addthis_32x32_style' => t('Big (32x32)'),
-      ),
-    );
-    $form['settings']['addthis_settings']['counter_orientation'] = array(
-      '#title' => t('Counter orientation'),
-      '#description' => t('Specify the way service counters are oriented.'),
-      '#type' => 'select',
-      '#default_value' => $this->configuration['counter_orientation'],
-      '#options' => array(
-        'horizontal' => t('Horizontal'),
-        'vertical' => t('Vertical'),
-      )
-    );
-    $form['settings']['addthis_settings']['extra_css'] = array(
-      '#title' => t('Extra CSS declaration'),
-      '#type' => 'textfield',
-      '#size' => 40,
-      '#default_value' => $this->configuration['extra_css'],
-      '#description' => t('Specify extra CSS classes to apply to the toolbox'),
-    );
+    $form['settings']['addthis_settings'] += $elements;
+
     return $form;
   }
   public function blockSubmit($form, FormStateInterface $form_state) {

--- a/addthis_block/src/Plugin/Block/AddThisBlock.php
+++ b/addthis_block/src/Plugin/Block/AddThisBlock.php
@@ -42,7 +42,9 @@ class AddThisBlock extends BlockBase
     );
   }
 
-
+  /**
+   * {@inheritdoc}
+   */
   function blockForm($form, FormStateInterface $form_state)
   {
 
@@ -91,10 +93,19 @@ class AddThisBlock extends BlockBase
     return $form;
   }
 
+  /**
+   * Callback for AddThisBlock blockForm() to control sub-settings based on display type.
+   * @param array $form
+   * @param FormStateInterface $form_state
+   * @return mixed
+   */
   public function addthisAjaxCallback(array $form, FormStateInterface $form_state){
     return $form['settings']['settings']['addthis_settings']['type_settings'];
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function blockSubmit($form, FormStateInterface $form_state)
   {
     $this->configuration['type'] = $form_state->getValue(['settings', 'addthis_settings', 'type']);

--- a/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicButtonFormatter.php
+++ b/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicButtonFormatter.php
@@ -10,7 +10,6 @@ use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\addthis\AddThis;
-use Drupal\addthis\Services\AddThisScriptManager;
 
 
 /**
@@ -40,24 +39,9 @@ class AddThisBasicButtonFormatter extends FormatterBase {
    * {@inheritdoc}
    */
   public function settingsForm(array $form, FormStateInterface $form_state) {
-    $element = array();
+    $settings = $this->getSettings();
 
-    $element['button_size'] = array(
-      '#title' => t('Image'),
-      '#type' => 'select',
-      '#default_value' => $this->getSetting('button_size'),
-      '#options' => array(
-        'small' => t('Small'),
-        'big' => t('Big'),
-      ),
-    );
-    $element['extra_css'] = array(
-      '#title' => t('Extra CSS declaration'),
-      '#type' => 'textfield',
-      '#size' => 40,
-      '#default_value' => $this->getSetting('extra_css'),
-      '#description' => t('Specify extra CSS classes to apply to the button'),
-    );
+    $element = AddThis::getInstance()->getBasicButtonForm($this, $settings);
 
     return $element;
   }
@@ -67,44 +51,11 @@ class AddThisBasicButtonFormatter extends FormatterBase {
    * {@inheritdoc}
    */
   public function viewElements(FieldItemListInterface $items) {
-    //@TODO Implement viewElements()
-    $addthis = AddThis::getInstance();
-    //$settings = $options['#display']['settings'];
-
-    $button_img = 'http://s7.addthis.com/static/btn/sm-share-en.gif';
-    if (isset($settings['buttons_size']) && $settings['buttons_size'] == 'big') {
-      $button_img = 'http://s7.addthis.com/static/btn/v2/lg-share-en.gif';
-    }
-    //$button_img = $addthis->transformToSecureUrl($button_img);
-
-    //$extra_css = isset($settings['extra_css']) ? $settings['extra_css'] : '';
-    $element = array(
-      '#type' => 'addthis_wrapper',
-      '#tag' => 'a',
-      '#attributes' => array(
-        'class' => array(
-          'addthis_button',
-        ),
-      ),
+    $settings = $this->getSettings();
+    $markup = AddThis::getInstance()->getBasicButtonMarkup($settings);
+    return array(
+      '#markup' => $markup
     );
-    //$element['#attributes'] += $addthis->getAddThisAttributesMarkup($options);
-
-    // Add the widget script.
-    $script_manager = AddThisScriptManager::getInstance();
-    $script_manager->attachJsToElement($element);
-
-    // Create img button.
-    $image = array(
-      '#type' => 'addthis_element',
-      '#tag' => 'img',
-      '#attributes' => array(
-        'src' => $button_img,
-        'alt' => t('Share page with AddThis'),
-      ),
-    );
-    $element[] = $image;
-
-    return $element;
   }
 
 

--- a/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicButtonFormatter.php
+++ b/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicButtonFormatter.php
@@ -59,6 +59,4 @@ class AddThisBasicButtonFormatter extends FormatterBase {
   }
 
 
-
-
 }

--- a/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicToolboxFormatter.php
+++ b/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicToolboxFormatter.php
@@ -48,28 +48,11 @@ class AddThisBasicToolboxFormatter extends FormatterBase
     $settings = $this->getSettings();
     $element = array();
 
-    AddThis::getInstance()->getBasicToolboxForm($settings);
+    AddThis::getInstance()->getBasicToolboxForm($this, $settings);
 
     return $element;
   }
 
-  public function addThisDisplayElementServicesValidate(array $element, FormStateInterface $form_state)
-  {
-    $bad = FALSE;
-
-    $services = trim($element['#value']);
-    $services = str_replace(' ', '', $services);
-
-    if (!preg_match('/^[a-z\_\,0-9]+$/', $services)) {
-      $bad = TRUE;
-    }
-    // @todo Validate the service names against AddThis.com. Give a notice when there are bad names.
-
-    // Return error.
-    if ($bad) {
-      form_error($element, t('The declared services are incorrect or nonexistent.'));
-    }
-  }
 
   /**
    * {@inheritdoc}

--- a/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicToolboxFormatter.php
+++ b/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicToolboxFormatter.php
@@ -23,12 +23,14 @@ use Drupal\addthis\Services\AddThisScriptManager;
  *   }
  * )
  */
-class AddThisBasicToolboxFormatter extends FormatterBase {
+class AddThisBasicToolboxFormatter extends FormatterBase
+{
 
   /**
    * {@inheritdoc}
    */
-  public static function defaultSettings() {
+  public static function defaultSettings()
+  {
     return array(
       'share_services' => 'facebook,twitter',
       'buttons_size' => 'addthis_16x16_style',
@@ -40,53 +42,19 @@ class AddThisBasicToolboxFormatter extends FormatterBase {
   /**
    * {@inheritdoc}
    */
-  public function settingsForm(array $form, FormStateInterface $form_state) {
+  public function settingsForm(array $form, FormStateInterface $form_state)
+  {
+
+    $settings = $this->getSettings();
     $element = array();
 
-    $element['share_services'] = array(
-      '#title' => t('Services'),
-      '#type' => 'textfield',
-      '#size' => 80,
-      '#default_value' => $this->getSetting('share_services'),
-      '#required' => TRUE,
-      '#element_validate' => array($this, 'addThisDisplayElementServicesValidate'),
-      '#description' =>
-        t('Specify the names of the sharing services and seperate them with a , (comma). <a href="http://www.addthis.com/services/list" target="_blank">The names on this list are valid.</a>') .
-        t('Elements that are available but not ont the services list are (!services).',
-          array('!services' => 'bubble_style, pill_style, tweet, facebook_send, twitter_follow_native, google_plusone, stumbleupon_badge, counter_* (several supported services), linkedin_counter')
-        ),
-    );
-    $element['buttons_size'] = array(
-      '#title' => t('Buttons size'),
-      '#type' => 'select',
-      '#default_value' => $this->getSetting('buttons_size'),
-      '#options' => array(
-        'addthis_16x16_style' => t('Small (16x16)'),
-        'addthis_32x32_style' => t('Big (32x32)'),
-      ),
-    );
-    $element['counter_orientation'] = array(
-      '#title' => t('Counter orientation'),
-      '#description' => t('Specify the way service counters are oriented.'),
-      '#type' => 'select',
-      '#default_value' => $this->getSetting('counter_orientation'),
-      '#options' => array(
-        'horizontal' => t('Horizontal'),
-        'vertical' => t('Vertical'),
-      )
-    );
-    $element['extra_css'] = array(
-      '#title' => t('Extra CSS declaration'),
-      '#type' => 'textfield',
-      '#size' => 40,
-      '#default_value' => $this->getSetting('extra_css'),
-      '#description' => t('Specify extra CSS classes to apply to the toolbox'),
-    );
+    AddThis::getInstance()->getBasicToolboxForm($settings);
 
     return $element;
   }
 
-  public function addThisDisplayElementServicesValidate(array $element, FormStateInterface $form_state){
+  public function addThisDisplayElementServicesValidate(array $element, FormStateInterface $form_state)
+  {
     $bad = FALSE;
 
     $services = trim($element['#value']);
@@ -106,8 +74,8 @@ class AddThisBasicToolboxFormatter extends FormatterBase {
   /**
    * {@inheritdoc}
    */
-  public function viewElements(FieldItemListInterface $items) {
-
+  public function viewElements(FieldItemListInterface $items)
+  {
     $widget_settings = $this->getSettings();
 
     $element = array(
@@ -122,6 +90,7 @@ class AddThisBasicToolboxFormatter extends FormatterBase {
         ),
       ),
     );
+
 
     // Add the widget script.
     $script_manager = AddThisScriptManager::getInstance();

--- a/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicToolboxFormatter.php
+++ b/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicToolboxFormatter.php
@@ -10,7 +10,6 @@ use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\addthis\AddThis;
-use Drupal\addthis\Services\AddThisScriptManager;
 
 /**
  * Plugin implementation of the 'addthis_basic_toolbox' formatter.
@@ -59,100 +58,10 @@ class AddThisBasicToolboxFormatter extends FormatterBase
    */
   public function viewElements(FieldItemListInterface $items)
   {
-    $widget_settings = $this->getSettings();
+    $settings = $this->getSettings();
 
-    $element = array(
-      '#type' => 'addthis_wrapper',
-      '#tag' => 'div',
-      '#attributes' => array(
-        'class' => array(
-          'addthis_toolbox',
-          'addthis_default_style',
-          ($widget_settings['buttons_size'] == AddThis::CSS_32x32 ? AddThis::CSS_32x32 : NULL),
-          $widget_settings['extra_css'],
-        ),
-      ),
-    );
+    $markup = AddThis::getInstance()->getBasicToolboxMarkup($settings);
 
-
-    // Add the widget script.
-    $script_manager = AddThisScriptManager::getInstance();
-    $script_manager->attachJsToElement($element);
-
-    $services = trim($widget_settings['share_services']);
-    $services = str_replace(' ', '', $services);
-    $services = explode(',', $services);
-    $items = array();
-
-    // All service elements
-    $items = array();
-    foreach ($services as $service) {
-      $items[$service] = array(
-        '#type' => 'addthis_element',
-        '#tag' => 'a',
-        '#value' => '',
-        '#attributes' => array(
-          'href' => AddThis::getInstance()->getBaseBookmarkUrl(),
-          'class' => array(
-            'addthis_button_' . $service,
-          ),
-        ),
-        '#addthis_service' => $service,
-      );
-
-      // Add individual counters.
-      if (strpos($service, 'counter_') === 0) {
-        $items[$service]['#attributes']['class'] = array("addthis_$service");
-      }
-
-      // Basic implementations of bubble counter orientation.
-      // @todo Figure all the bubbles out and add them.
-      //   Still missing: tweetme, hyves and stubleupon, google_plusone_badge.
-      //
-      $orientation = ($widget_settings['counter_orientation'] == 'horizontal' ? TRUE : FALSE);
-      switch ($service) {
-        case 'linkedin_counter':
-          $items[$service]['#attributes'] += array(
-            'li:counter' => ($orientation ? '' : 'top'),
-          );
-          break;
-        case 'facebook_like':
-          $items[$service]['#attributes'] += array(
-            'fb:like:layout' => ($orientation ? 'button_count' : 'box_count')
-          );
-          break;
-        case 'facebook_share':
-          $items[$service]['#attributes'] += array(
-            'fb:share:layout' => ($orientation ? 'button_count' : 'box_count')
-          );
-          break;
-        case 'google_plusone':
-          $items[$service]['#attributes'] += array(
-            'g:plusone:size' => ($orientation ? 'standard' : 'tall')
-          );
-          break;
-        case 'tweet':
-          $items[$service]['#attributes'] += array(
-            'tw:count' => ($orientation ? 'horizontal' : 'vertical'),
-            'tw:via' => AddThis::getInstance()->getTwitterVia(),
-          );
-          break;
-        case 'bubble_style':
-          $items[$service]['#attributes']['class'] = array(
-            'addthis_counter', 'addthis_bubble_style'
-          );
-          break;
-        case 'pill_style':
-          $items[$service]['#attributes']['class'] = array(
-            'addthis_counter', 'addthis_pill_style'
-          );
-          break;
-      }
-    }
-
-    $element += $items;
-
-    $markup = render($element);
     return array(
       '#markup' => $markup
     );

--- a/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicToolboxFormatter.php
+++ b/addthis_fields/src/Plugin/Field/FieldFormatter/AddThisBasicToolboxFormatter.php
@@ -22,14 +22,12 @@ use Drupal\addthis\AddThis;
  *   }
  * )
  */
-class AddThisBasicToolboxFormatter extends FormatterBase
-{
+class AddThisBasicToolboxFormatter extends FormatterBase {
 
   /**
    * {@inheritdoc}
    */
-  public static function defaultSettings()
-  {
+  public static function defaultSettings() {
     return array(
       'share_services' => 'facebook,twitter',
       'buttons_size' => 'addthis_16x16_style',
@@ -41,8 +39,7 @@ class AddThisBasicToolboxFormatter extends FormatterBase
   /**
    * {@inheritdoc}
    */
-  public function settingsForm(array $form, FormStateInterface $form_state)
-  {
+  public function settingsForm(array $form, FormStateInterface $form_state) {
 
     $settings = $this->getSettings();
     $element = array();
@@ -56,8 +53,7 @@ class AddThisBasicToolboxFormatter extends FormatterBase
   /**
    * {@inheritdoc}
    */
-  public function viewElements(FieldItemListInterface $items)
-  {
+  public function viewElements(FieldItemListInterface $items) {
     $settings = $this->getSettings();
 
     $markup = AddThis::getInstance()->getBasicToolboxMarkup($settings);

--- a/css/addthis.admin.css
+++ b/css/addthis.admin.css
@@ -1,11 +1,13 @@
 .addthis_service_icon {
-  display: inline-block;
-  padding-left: 20px;
+    display: inline-block;
+    padding-left: 20px;
 }
+
 #edit-addthis-enabled-services .form-item, #edit-addthis-excluded-services .form-item {
-  float: left;
-  width: 20%;
+    float: left;
+    width: 20%;
 }
+
 #edit-addthis-enabled-services .form-item .description {
-  clear: both;
+    clear: both;
 }

--- a/js/addthis.js
+++ b/js/addthis.js
@@ -4,94 +4,93 @@
  */
 
 (function ($, Drupal, drupalSettings) {
-  Drupal.behaviors.addthis = {
-    scriptLoaded: false,
-    attach: function(context, settings) {
+    Drupal.behaviors.addthis = {
+        scriptLoaded: false,
+        attach: function (context, settings) {
 
-      // The addthis configuration is not loaded but the settings are passed
-      // to do so.
-      if (!this.isConfigLoaded() && this.isSettingsLoaded()) {
-        // Initialize config.
-        this.initConfig();
+            // The addthis configuration is not loaded but the settings are passed
+            // to do so.
+            if (!this.isConfigLoaded() && this.isSettingsLoaded()) {
+                // Initialize config.
+                this.initConfig();
 
-        // Load widget js.
-        if (!this.scriptLoaded) {
-          this.loadDomready();
+                // Load widget js.
+                if (!this.scriptLoaded) {
+                    this.loadDomready();
+                }
+            }
+            // The addthis configuration is not loaded but no setting are available
+            // to load anything.
+            else if (!this.isConfigLoaded() && !this.isSettingsLoaded()) {
+                // Do nothing
+            }
+
+            // Trigger ready on ajax attach.
+            if (context != window.document) {
+                Drupal.behaviors.addthis.ajaxLoad(context, settings);
+            }
+
+        },
+
+        // Returns if the settings defined by the addthis module are loaded.
+        isSettingsLoaded: function () {
+            if (typeof drupalSettings.addthis == 'undefined') {
+                return false;
+            }
+            return true;
+        },
+
+        // Returns if the configuration variables needed for widget.js are defined.
+        isConfigLoaded: function () {
+            if (typeof addthis_config == 'undefined' || typeof addthis_share == 'undefined') {
+                return false;
+            }
+            return true;
+        },
+
+        initConfig: function () {
+            addthis_config = drupalSettings.addthis.addthis_config;
+            addthis_share = drupalSettings.addthis.addthis_share;
+        },
+
+        // Load the js library when the dom is ready.
+        loadDomready: function () {
+            // If settings asks for loading the script after the dom is loaded, then
+            // load the script here.
+            if (!this.scriptLoaded &&
+                this.isConfigLoaded() &&
+                drupalSettings.addthis.domready) {
+                $.getScript(drupalSettings.addthis.widget_url, Drupal.behaviors.addthis.scriptReady);
+            }
+        },
+
+        // Callback for loading the widget.js dynamically.
+        scriptReady: function () {
+            this.scriptLoaded = true;
+        },
+
+        // Called when a ajax request returned.
+        ajaxLoad: function (context, settings) {
+            if (typeof window.addthis != 'undefined' &&
+                typeof window.addthis.toolbox == 'function') {
+                window.addthis.toolbox('.addthis_toolbox');
+            }
         }
-      }
-      // The addthis configuration is not loaded but no setting are available
-      // to load anything.
-      else if(!this.isConfigLoaded() && !this.isSettingsLoaded()) {
-        // Do nothing
-      }
 
-      // Trigger ready on ajax attach.
-      if (context != window.document) {
-        Drupal.behaviors.addthis.ajaxLoad(context, settings);
-      }
+    };
 
-    },
-
-    // Returns if the settings defined by the addthis module are loaded.
-    isSettingsLoaded: function () {
-      if (typeof drupalSettings.addthis == 'undefined') {
-        return false;
-      }
-      return true;
-    },
-
-    // Returns if the configuration variables needed for widget.js are defined.
-    isConfigLoaded: function() {
-      if (typeof addthis_config == 'undefined' || typeof addthis_share == 'undefined') {
-        return false;
-      }
-      return true;
-    },
-
-    initConfig: function () {
-      addthis_config = drupalSettings.addthis.addthis_config;
-      addthis_share = drupalSettings.addthis.addthis_share;
-    },
-
-    // Load the js library when the dom is ready.
-    loadDomready: function() {
-      // If settings asks for loading the script after the dom is loaded, then
-      // load the script here.
-      if (!this.scriptLoaded &&
-          this.isConfigLoaded() &&
-          drupalSettings.addthis.domready) {
-        $.getScript(drupalSettings.addthis.widget_url, Drupal.behaviors.addthis.scriptReady);
-      }
-    },
-
-    // Callback for loading the widget.js dynamically.
-    scriptReady: function () {
-      this.scriptLoaded = true;
-    },
-
-    // Called when a ajax request returned.
-    ajaxLoad: function(context, settings) {
-      if (typeof window.addthis != 'undefined' &&
-          typeof window.addthis.toolbox == 'function')
-      {
-          window.addthis.toolbox('.addthis_toolbox');
-      }
+    // This load the config in time to run any addthis functionality.
+    if (Drupal.behaviors.addthis.isConfigLoaded()) {
+        addthis_config = drupalSettings.addthis.addthis_config;
+        addthis_share = drupalSettings.addthis.addthis_share;
     }
 
-  };
-
-  // This load the config in time to run any addthis functionality.
-  if (Drupal.behaviors.addthis.isConfigLoaded()) {
-    addthis_config = drupalSettings.addthis.addthis_config;
-    addthis_share = drupalSettings.addthis.addthis_share;
-  }
-
-  // Document ready in case we want to load AddThis into the dom after every
-  // thing is loaded.
-  //
-  // Is executed once after the attach happened.
-  $(document).ready(function() {
-    Drupal.behaviors.addthis.loadDomready();
-  });
+    // Document ready in case we want to load AddThis into the dom after every
+    // thing is loaded.
+    //
+    // Is executed once after the attach happened.
+    $(document).ready(function () {
+        Drupal.behaviors.addthis.loadDomready();
+    });
 
 }(jQuery, Drupal, drupalSettings));

--- a/src/AddThis.php
+++ b/src/AddThis.php
@@ -100,17 +100,19 @@ class AddThis {
     $this->json = $json;
   }
 
-  public function setConfig(){
+  public function setConfig() {
     $this->config = \Drupal::config('addthis.settings');
   }
-
 
 
   public function getServices() {
     $rows = array();
     $services = $this->json->decode($this->getServicesJsonUrl());
     if (empty($services)) {
-      drupal_set_message(t('AddThis services could not be loaded from @service_url', array('@service_url', $this->getServicesJsonUrl())), 'warning');
+      drupal_set_message(t('AddThis services could not be loaded from @service_url', array(
+        '@service_url',
+        $this->getServicesJsonUrl()
+      )), 'warning');
     }
     else {
       foreach ($services['data'] as $service) {
@@ -137,7 +139,8 @@ class AddThis {
     $settings = $block_widget_settings;
 
     if ($settings == NULL && $widget_type != self::WIDGET_TYPE_DISABLED) {
-      $settings =  \Drupal::service('plugin.manager.field.formatter')->getDefaultSettings($widget_type);
+      $settings = \Drupal::service('plugin.manager.field.formatter')
+        ->getDefaultSettings($widget_type);
 
     }
 
@@ -156,7 +159,6 @@ class AddThis {
     $service_json_url_key = isset($service_json_url_key) ? $service_json_url_key : self::DEFAULT_SERVICES_JSON_URL;
     return check_url($service_json_url_key);
   }
-
 
 
   /**
@@ -222,7 +224,6 @@ class AddThis {
   }
 
 
-
   public function getFullBookmarkUrl() {
     return $this->getBaseBookmarkUrl() . $this->getProfileIdQueryParameterPrefixedWithAmp();
   }
@@ -255,7 +256,7 @@ class AddThis {
    * @param $options
    * @return array
    */
-  public function getBasicToolboxForm($parent_class, $options){
+  public function getBasicToolboxForm($parent_class, $options) {
     $element = array();
 
     $element['share_services'] = array(
@@ -265,7 +266,10 @@ class AddThis {
       '#default_value' => $options['share_services'],
       '#required' => TRUE,
       //Validate function is defined in addthis.module.
-      '#element_validate' => array($parent_class, 'addThisDisplayElementServicesValidate'),
+      '#element_validate' => array(
+        $parent_class,
+        'addThisDisplayElementServicesValidate'
+      ),
       '#description' =>
         t('Specify the names of the sharing services and seperate them with a , (comma). <a href="http://www.addthis.com/services/list" target="_blank">The names on this list are valid.</a>') .
         t('Elements that are available but not ont the services list are (!services).',
@@ -311,7 +315,7 @@ class AddThis {
    * @param $options
    * @return array
    */
-  public function getBasicButtonForm($parent_class, $options){
+  public function getBasicButtonForm($parent_class, $options) {
     $element = array();
 
     $element['button_size'] = array(
@@ -340,7 +344,7 @@ class AddThis {
    * @param $settings
    * @return null
    */
-  function getBasicToolboxMarkup($settings){
+  function getBasicToolboxMarkup($settings) {
     $element = array(
       '#type' => 'addthis_wrapper',
       '#tag' => 'div',
@@ -419,12 +423,14 @@ class AddThis {
           break;
         case 'bubble_style':
           $items[$service]['#attributes']['class'] = array(
-            'addthis_counter', 'addthis_bubble_style'
+            'addthis_counter',
+            'addthis_bubble_style'
           );
           break;
         case 'pill_style':
           $items[$service]['#attributes']['class'] = array(
-            'addthis_counter', 'addthis_pill_style'
+            'addthis_counter',
+            'addthis_pill_style'
           );
           break;
       }
@@ -442,7 +448,7 @@ class AddThis {
    * @param $settings
    * @return null
    */
-  function getBasicButtonMarkup($settings){
+  function getBasicButtonMarkup($settings) {
     $button_img = 'http://s7.addthis.com/static/btn/sm-share-en.gif';
     if (isset($settings['buttons_size']) && $settings['buttons_size'] == 'big') {
       $button_img = 'http://s7.addthis.com/static/btn/v2/lg-share-en.gif';

--- a/src/AddThis.php
+++ b/src/AddThis.php
@@ -254,7 +254,7 @@ class AddThis {
    * @param $options
    * @return array
    */
-  public function getBasicToolboxForm($options){
+  public function getBasicToolboxForm($parent_class, $options){
     $element = array();
 
     $element['share_services'] = array(
@@ -263,7 +263,8 @@ class AddThis {
       '#size' => 80,
       '#default_value' => $options['share_services'],
       '#required' => TRUE,
-      '#element_validate' => array($this, 'addThisDisplayElementServicesValidate'),
+      //Validate function is defined in addthis.module.
+      '#element_validate' => array($parent_class, 'addThisDisplayElementServicesValidate'),
       '#description' =>
         t('Specify the names of the sharing services and seperate them with a , (comma). <a href="http://www.addthis.com/services/list" target="_blank">The names on this list are valid.</a>') .
         t('Elements that are available but not ont the services list are (!services).',

--- a/src/AddThis.php
+++ b/src/AddThis.php
@@ -303,6 +303,14 @@ class AddThis {
   }
 
 
+  /**
+   *
+   * Returns the basicButtonForm elements to be used in the Field and Block implementation.
+   *
+   * @param $parent_class
+   * @param $options
+   * @return array
+   */
   public function getBasicButtonForm($parent_class, $options){
     $element = array();
 
@@ -326,7 +334,12 @@ class AddThis {
     return $element;
   }
 
-
+  /**
+   * Returns rendered markup for the BasicToolbox display. This will be called
+   * from both the Field and Block render functions.
+   * @param $settings
+   * @return null
+   */
   function getBasicToolboxMarkup($settings){
     $element = array(
       '#type' => 'addthis_wrapper',
@@ -423,6 +436,12 @@ class AddThis {
   }
 
 
+  /**
+   * Returns rendered markup for the BasicButton display. This will be called
+   * from both the Field and Block render functions.
+   * @param $settings
+   * @return null
+   */
   function getBasicButtonMarkup($settings){
     $button_img = 'http://s7.addthis.com/static/btn/sm-share-en.gif';
     if (isset($settings['buttons_size']) && $settings['buttons_size'] == 'big') {

--- a/src/AddThis.php
+++ b/src/AddThis.php
@@ -248,6 +248,59 @@ class AddThis {
     return $displays;
   }
 
+  /**
+   * Provides options for the BasicToolboxForm. This is used in field & block
+   * configurations.
+   * @param $options
+   * @return array
+   */
+  public function getBasicToolboxForm($options){
+    $element = array();
+
+    $element['share_services'] = array(
+      '#title' => t('Services'),
+      '#type' => 'textfield',
+      '#size' => 80,
+      '#default_value' => $options['share_services'],
+      '#required' => TRUE,
+      '#element_validate' => array($this, 'addThisDisplayElementServicesValidate'),
+      '#description' =>
+        t('Specify the names of the sharing services and seperate them with a , (comma). <a href="http://www.addthis.com/services/list" target="_blank">The names on this list are valid.</a>') .
+        t('Elements that are available but not ont the services list are (!services).',
+          array('!services' => 'bubble_style, pill_style, tweet, facebook_send, twitter_follow_native, google_plusone, stumbleupon_badge, counter_* (several supported services), linkedin_counter')
+        ),
+    );
+    $element['buttons_size'] = array(
+      '#title' => t('Buttons size'),
+      '#type' => 'select',
+      '#default_value' => $options['buttons_size'],
+      '#options' => array(
+        'addthis_16x16_style' => t('Small (16x16)'),
+        'addthis_32x32_style' => t('Big (32x32)'),
+      ),
+    );
+    $element['counter_orientation'] = array(
+      '#title' => t('Counter orientation'),
+      '#description' => t('Specify the way service counters are oriented.'),
+      '#type' => 'select',
+      '#default_value' => $options['counter_orientation'],
+      '#options' => array(
+        'horizontal' => t('Horizontal'),
+        'vertical' => t('Vertical'),
+      )
+    );
+    $element['extra_css'] = array(
+      '#title' => t('Extra CSS declaration'),
+      '#type' => 'textfield',
+      '#size' => 40,
+      '#default_value' => $options['extra_css'],
+      '#description' => t('Specify extra CSS classes to apply to the toolbox'),
+    );
+
+    return $element;
+  }
+
+
 
 
 }

--- a/src/Element/AddThisElement.php
+++ b/src/Element/AddThisElement.php
@@ -36,11 +36,11 @@ class AddThisElement extends RenderElement {
    * @param $element
    * @return mixed
    */
-  public static function preRenderAddThisElement($element){
+  public static function preRenderAddThisElement($element) {
     if (!isset($element['#value'])) {
       $element['addthis_element'] = [
         '#markup' => '<' . $element['#tag'] . new Attribute($element['#attributes']) . " />\n"
-        ];
+      ];
       return $element;
     }
 
@@ -55,7 +55,7 @@ class AddThisElement extends RenderElement {
     $output .= '</' . $element['#tag'] . ">\n";
     $element['addthis_element'] = [
       '#markup' => $output,
-      ];
+    ];
 
     return $element;
   }

--- a/src/Element/AddThisWrapper.php
+++ b/src/Element/AddThisWrapper.php
@@ -9,6 +9,7 @@ namespace Drupal\addthis\Element;
 use Drupal\Core\Render\Element\RenderElement;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Render\Element;
+
 /**
  * Class AddThisElement
  *
@@ -35,18 +36,18 @@ class AddThisWrapper extends RenderElement {
    * @param $element
    * @return mixed
    */
-  public static function preRenderAddThisWrapper($element){
+  public static function preRenderAddThisWrapper($element) {
     $output = '<' . $element['#tag'] . new Attribute($element['#attributes']) . '>';
     $children = Element::children($element);
-     if (count($children) > 0) {
-       foreach ($children as $child) {
-         $output .= render($element[$child]);
-       }
-     }
+    if (count($children) > 0) {
+      foreach ($children as $child) {
+        $output .= render($element[$child]);
+      }
+    }
     $output .= '</' . $element['#tag'] . ">  \n";
     $element['addthis_wrapper'] = [
       '#markup' => $output
-      ];
+    ];
 
     return $element;
   }

--- a/src/Form/AddThisSettingsAdvancedForm.php
+++ b/src/Form/AddThisSettingsAdvancedForm.php
@@ -76,7 +76,8 @@ class AddThisSettingsAdvancedForm extends ConfigFormBase {
     $form['advanced_settings_fieldset'] = array(
       '#type' => 'fieldset',
       '#title' => t('Advanced settings'),
-      '#access' => \Drupal::currentUser()->hasPermission('administer advanced addthis'),
+      '#access' => \Drupal::currentUser()
+        ->hasPermission('administer advanced addthis'),
       '#collapsible' => TRUE,
       '#collapsed' => TRUE,
     );

--- a/src/Form/AddThisSettingsForm.php
+++ b/src/Form/AddThisSettingsForm.php
@@ -167,7 +167,7 @@ class AddThisSettingsForm extends ConfigFormBase {
       '#columns' => 3,
     );
 
-     //Analytics settings.
+    //Analytics settings.
     $profile_id = $config->get('analytics.addthis_profile_id');
     $can_track_clicks = empty($profile_id) ? FALSE : TRUE;
     $form['fieldset_analytics'] = array(
@@ -233,9 +233,10 @@ class AddThisSettingsForm extends ConfigFormBase {
     );
 
     // Google Analytics and Google Social Tracking support.
-    $can_do_google_social_tracking = \Drupal::moduleHandler()->moduleExists('googleanalytics');
+    $can_do_google_social_tracking = \Drupal::moduleHandler()
+      ->moduleExists('googleanalytics');
     //@TODO Get back to this.
-    $google_analytics_config = \Drupal::config(google_analytics.settings);
+    $google_analytics_config = \Drupal::config(google_analytics . settings);
     $google_analytics_account = $google_analytics_config->get('google_analytics_account');
     $is_google_analytics_setup = $can_do_google_social_tracking && isset($google_analytics_account);
     $form['fieldset_analytics']['google_analytics'] = array(

--- a/src/Plugin/Field/FieldFormatter/AddThisFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/AddThisFormatter.php
@@ -1,8 +1,8 @@
 <?php
 /**
-* @file
-* Contains \Drupal\addthis\Plugin\Field\FieldFormatter\AddThisFormatter.
-*/
+ * @file
+ * Contains \Drupal\addthis\Plugin\Field\FieldFormatter\AddThisFormatter.
+ */
 
 namespace Drupal\addthis\Plugin\Field\FieldFormatter;
 
@@ -11,16 +11,16 @@ use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
-* Plugin implementation of the 'addthis_disabled' formatter.
-*
-* @FieldFormatter(
-*   id = "addthis_disabled",
-*   label = @Translation("AddThis Disabled"),
-*   field_types = {
-*     "addthis"
-*   }
-* )
-*/
+ * Plugin implementation of the 'addthis_disabled' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "addthis_disabled",
+ *   label = @Translation("AddThis Disabled"),
+ *   field_types = {
+ *     "addthis"
+ *   }
+ * )
+ */
 class AddThisFormatter extends FormatterBase {
   /**
    * {@inheritdoc}
@@ -29,7 +29,6 @@ class AddThisFormatter extends FormatterBase {
     //@TODO Implement viewElements()
     $element = array();
     $display_type = 'addthis_disabled';
-
 
 
     $markup = array(

--- a/src/Plugin/Field/FieldType/AddThisItem.php
+++ b/src/Plugin/Field/FieldType/AddThisItem.php
@@ -66,12 +66,17 @@ class AddThisItem extends FieldItemBase {
     $constraints = parent::getConstraints();
 
     if ($max_length = $this->getSetting('max_length')) {
-      $constraint_manager = \Drupal::typedDataManager()->getValidationConstraintManager();
+      $constraint_manager = \Drupal::typedDataManager()
+        ->getValidationConstraintManager();
       $constraints[] = $constraint_manager->create('ComplexData', array(
         'value' => array(
           'Length' => array(
             'max' => $max_length,
-            'maxMessage' => t('%name: may not be longer than @max characters.', array('%name' => $this->getFieldDefinition()->getLabel(), '@max' => $max_length)),
+            'maxMessage' => t('%name: may not be longer than @max characters.', array(
+              '%name' => $this->getFieldDefinition()
+                ->getLabel(),
+              '@max' => $max_length
+            )),
           ),
         ),
       ));

--- a/src/Plugin/Field/FieldWidget/AddThisWidget.php
+++ b/src/Plugin/Field/FieldWidget/AddThisWidget.php
@@ -29,8 +29,7 @@ class AddThisWidget extends WidgetBase {
    * {@inheritdoc}
    */
   public static function defaultSettings() {
-    return array(
-    ) + parent::defaultSettings();
+    return array() + parent::defaultSettings();
   }
 
   /**

--- a/src/Services/AddThisScriptManager.php
+++ b/src/Services/AddThisScriptManager.php
@@ -27,8 +27,10 @@ class AddThisScriptManager {
    * Construct method.
    */
   private function __construct() {
-    $this->async = \Drupal::config('addthis.settings.advanced')->get('addthis_widget_load_async');
-    $this->domready = \Drupal::config('addthis.settings.advanced')->get('addthis_widget_load_domready');
+    $this->async = \Drupal::config('addthis.settings.advanced')
+      ->get('addthis_widget_load_async');
+    $this->domready = \Drupal::config('addthis.settings.advanced')
+      ->get('addthis_widget_load_domready');
   }
 
   /**
@@ -52,7 +54,8 @@ class AddThisScriptManager {
    *   A url reference to the widget js.
    */
   public function getWidgetJsUrl() {
-    return check_url(\Drupal::config('addthis.settings.advanced')->get('addthis_widget_js_url'));
+    return check_url(\Drupal::config('addthis.settings.advanced')
+      ->get('addthis_widget_js_url'));
   }
 
   /**
@@ -79,7 +82,7 @@ class AddThisScriptManager {
   public function correctSchemaIfHttps($url) {
     if (is_string($url) && $this->isHttps()) {
       return str_replace('http://', 'https://', $url);
-    } 
+    }
     else {
       return $url;
     }
@@ -192,12 +195,13 @@ class AddThisScriptManager {
     );
     if (\Drupal::moduleHandler()->moduleExists('googleanalytics')) {
       if ($config->get('analytics.addthis_google_analytics_tracking_enabled')) {
-        $configuration['data_ga_property'] = \Drupal::config(google_analytics.settings)->get('google_analytics_account');
+        $configuration['data_ga_property'] = \Drupal::config(google_analytics . settings)
+          ->get('google_analytics_account');
         $configuration['data_ga_social'] = $config->get('analytics.addthis_google_analytics_social_tracking_enabled');
       }
     }
 
-   // drupal_alter('addthis_configuration', $configuration);
+    // drupal_alter('addthis_configuration', $configuration);
     return $configuration;
   }
 
@@ -220,7 +224,8 @@ class AddThisScriptManager {
         'templates' => $configuration['templates'],
       );
     }
-    $addthis_share['templates']['twitter'] = \Drupal::config('addthis.settings')->get('third_party.addthis_twitter_template');
+    $addthis_share['templates']['twitter'] = \Drupal::config('addthis.settings')
+      ->get('third_party.addthis_twitter_template');
 
     //drupal_alter('addthis_configuration_share', $configuration);
     return $addthis_share;

--- a/src/Util/AddThisJson.php
+++ b/src/Util/AddThisJson.php
@@ -18,7 +18,8 @@ class AddThisJson {
       $response = \Drupal::httpClient()
         ->get($url)
         ->getBody(TRUE);
-    } catch (RequestException $e) {
+    }
+    catch (RequestException $e) {
       // Do some stuff in case of the error.
     }
 


### PR DESCRIPTION
- Abstracted out the BasicButton and BasicToolbox forms to allow for reuse in field/block
- Abstracted out displays for BasicButton and BasicToolbox to allow for reuse in field/block
- Updated Block settings form to allow for Type selection and conditional display of subfields
- Updated Block/Fields Form and Display functions to call shared functions
- Hooked up Services validation function for the BasicToolbox form
