### PR TITLE
changing fieldsets to details, per new d8 form api

### DIFF
--- a/src/Form/AddThisSettingsAdvancedForm.php
+++ b/src/Form/AddThisSettingsAdvancedForm.php
@@ -41,31 +41,30 @@ class AddThisSettingsAdvancedForm extends ConfigFormBase {
     $form['#attached']['library'][] = 'addthis/addthis.admin';
 
     // Service URL's settings.
-    $form['service_urls_fieldset'] = array(
-      '#type' => 'fieldset',
+    $form['service_urls_details'] = array(
+      '#type' => 'details',
       '#title' => t('Service URLs'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
+      '#open' => TRUE,
     );
-    $form['service_urls_fieldset']['addthis_bookmark_url'] = array(
+    $form['service_urls_details']['addthis_bookmark_url'] = array(
       '#type' => 'textfield',
       '#title' => t('AddThis bookmark URL'),
       '#default_value' => $config->get('addthis_bookmark_url'),
       '#required' => TRUE,
     );
-    $form['service_urls_fieldset']['addthis_services_css_url'] = array(
+    $form['service_urls_details']['addthis_services_css_url'] = array(
       '#type' => 'textfield',
       '#title' => t('AddThis services stylesheet URL'),
       '#default_value' => $config->get('addthis_services_css_url'),
       '#required' => TRUE,
     );
-    $form['service_urls_fieldset']['addthis_services_json_url'] = array(
+    $form['service_urls_details']['addthis_services_json_url'] = array(
       '#type' => 'textfield',
       '#title' => t('AddThis services json URL'),
       '#default_value' => $config->get('addthis_services_json_url'),
       '#required' => TRUE,
     );
-    $form['service_urls_fieldset']['addthis_widget_js_url'] = array(
+    $form['service_urls_details']['addthis_widget_js_url'] = array(
       '#type' => 'textfield',
       '#title' => t('AddThis javascript widget URL'),
       '#default_value' => $config->get('addthis_widget_js_url'),
@@ -73,40 +72,39 @@ class AddThisSettingsAdvancedForm extends ConfigFormBase {
     );
 
     // Advanced settings.
-    $form['advanced_settings_fieldset'] = array(
-      '#type' => 'fieldset',
+    $form['advanced_settings_details'] = array(
+      '#type' => 'details',
       '#title' => t('Advanced settings'),
       '#access' => \Drupal::currentUser()
         ->hasPermission('administer advanced addthis'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
+      '#open' => TRUE,
     );
-    $form['advanced_settings_fieldset']['addthis_custom_configuration_code_enabled'] = array(
+    $form['advanced_settings_details']['addthis_custom_configuration_code_enabled'] = array(
       '#type' => 'checkbox',
       '#title' => t('Use custom AddThis configuration code'),
       '#default_value' => $config->get('addthis_custom_configuration_code_enabled'),
       '#required' => FALSE,
       '#description' => t('Use custom AddThis configuration code. If checked, custom configuration will be used instead of other configuration settings provided in AddThis administration user interface.'),
     );
-    $form['advanced_settings_fieldset']['addthis_custom_configuration_code'] = array(
+    $form['advanced_settings_details']['addthis_custom_configuration_code'] = array(
       '#type' => 'textarea',
       '#title' => t('AddThis custom configuration code'),
       '#default_value' => $config->get('addthis_custom_configuration_code'),
       '#required' => FALSE,
       '#description' => t('AddThis custom configuration code. See format at <a href="http://addthis.com/" target="_blank">AddThis.com</a>'),
     );
-    $form['advanced_settings_fieldset']['addthis_widget_load_domready'] = array(
+    $form['advanced_settings_details']['addthis_widget_load_domready'] = array(
       '#type' => 'checkbox',
       '#title' => t('Load the AddThis resources after the DOM is ready.'),
       '#default_value' => $config->get('addthis_widget_load_domready'),
     );
-    $form['advanced_settings_fieldset']['addthis_widget_load_async'] = array(
+    $form['advanced_settings_details']['addthis_widget_load_async'] = array(
       '#type' => 'checkbox',
       '#title' => t('Initialize asynchronously through addthis.init().'),
       '#description' => t('Use this when you have your own Ajax functionality or create things after the DOM is ready trough Javascript. Initialize the addthis functionality through addthis.init().'),
       '#default_value' => $config->get('addthis_widget_load_async'),
     );
-    $form['advanced_settings_fieldset']['addthis_widget_include'] = array(
+    $form['advanced_settings_details']['addthis_widget_include'] = array(
       '#type' => 'select',
       '#title' => t('Load widget js.'),
       '#options' => array(

--- a/src/Form/AddThisSettingsForm.php
+++ b/src/Form/AddThisSettingsForm.php
@@ -11,6 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Extension\ModuleHandler;
 use Drupal\Component\Utility\Xss;
 use Drupal\addthis\AddThis;
+use Symfony\Component\Validator\Constraints\False;
 
 /**
  * Defines a form to configure maintenance settings for this site.
@@ -41,20 +42,19 @@ class AddThisSettingsForm extends ConfigFormBase {
     $form['#attached']['library'][] = 'addthis/addthis.admin';
 
     // Visual settings.
-    $form['fieldset_compact_menu'] = array(
-      '#type' => 'fieldset',
+    $form['details_compact_menu'] = array(
+      '#type' => 'details',
       '#title' => t('Compact menu'),
-      '#collapsible' => FALSE,
-      '#collapsed' => TRUE,
-      '#description' => '<p>' . t('Configure the global behavior and style of the compact menu and some additional settings related to the interface.') . '</p>'
+      '#open' => TRUE,
+      '#description' => '<p>' . t('Configure the global behavior and style of the compact menu and some additional settings related to the interface.') . '</p>',
+      '#description_display' => 'before'
     );
-    $form['fieldset_compact_menu']['fieldset_menu_style'] = array(
-      '#type' => 'fieldset',
+    $form['details_compact_menu']['details_menu_style'] = array(
+      '#type' => 'details',
       '#title' => t('Style'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
+      '#open' => FALSE,
     );
-    $form['fieldset_compact_menu']['fieldset_menu_style']['addthis_co_brand'] = array(
+    $form['details_compact_menu']['details_menu_style']['addthis_co_brand'] = array(
       '#type' => 'textfield',
       '#title' => t('Branding text'),
       '#description' => t('Additional branding message to be rendered in the upper-right-hand corner of the compact menus.<br />Should be less than 15 characters in most cases to render properly.'),
@@ -62,39 +62,39 @@ class AddThisSettingsForm extends ConfigFormBase {
       '#required' => FALSE,
       '#maxlength' => 15,
     );
-    $form['fieldset_compact_menu']['fieldset_menu_style']['addthis_ui_header_color'] = array(
+    $form['details_compact_menu']['details_menu_style']['addthis_ui_header_color'] = array(
       '#type' => 'textfield',
       '#title' => t('Header text color'),
       '#default_value' => $config->get('compact_menu.menu_style.addthis_ui_header_color'),
-      '#description' => t('Something like #FFFFFF'),
+      '#description' => t('Something like \'#FFFFFF\'.'),
       '#size' => 8,
       '#maxlength' => 7,
       '#required' => FALSE,
     );
-    $form['fieldset_compact_menu']['fieldset_menu_style']['addthis_ui_header_background_color'] = array(
+    $form['details_compact_menu']['details_menu_style']['addthis_ui_header_background_color'] = array(
       '#type' => 'textfield',
       '#title' => t('Header background color'),
       '#default_value' => $config->get('compact_menu.menu_style.addthis_ui_header_background_color'),
-      '#description' => t('Something like #000000'),
+      '#description' => t('Something like \'#000000\'.'),
       '#size' => 8,
       '#maxlength' => 7,
       '#required' => FALSE,
     );
-    $form['fieldset_compact_menu']['fieldset_menu_style']['addthis_click_to_open_compact_menu_enabled'] = array(
+    $form['details_compact_menu']['details_menu_style']['addthis_click_to_open_compact_menu_enabled'] = array(
       '#type' => 'checkbox',
       '#title' => t('Open compact menu on click'),
       '#description' => t('Default behavior is to open compact menu on hover.'),
       '#default_value' => $config->get('compact_menu.menu_style.addthis_click_to_open_compact_menu_enabled'),
       '#required' => FALSE,
     );
-    $form['fieldset_compact_menu']['fieldset_menu_style']['addthis_open_windows_enabled'] = array(
+    $form['details_compact_menu']['details_menu_style']['addthis_open_windows_enabled'] = array(
       '#type' => 'checkbox',
       '#title' => t('Use pop-up windows'),
       '#description' => t('If checked, all shares will open in a new pop-up window instead of a new tab or regular browser window.'),
       '#default_value' => $config->get('compact_menu.menu_style.addthis_open_windows_enabled'),
       '#required' => FALSE,
     );
-    $form['fieldset_compact_menu']['fieldset_menu_style']['addthis_ui_delay'] = array(
+    $form['details_compact_menu']['details_menu_style']['addthis_ui_delay'] = array(
       '#type' => 'textfield',
       '#title' => t('Menu open delay'),
       '#description' => t('Delay, in milliseconds, before compact menu appears when mousing over a regular button. Capped at 500 ms.'),
@@ -105,14 +105,14 @@ class AddThisSettingsForm extends ConfigFormBase {
     );
 
     // Enabled services settings.
-    $form['fieldset_compact_menu']['enabled_services_fieldset'] = array(
-      '#type' => 'fieldset',
+    $form['details_compact_menu']['enabled_services_details'] = array(
+      '#type' => 'details',
       '#title' => t('Compact menu enabled services'),
       '#description' => t('The sharing services you select here will be displayed in the compact menu. If you select no services, AddThis will provide a list of frequently used services. This list is updated regularly. <b>Notice that this setting does not define what services should be display in a toolbox.</b>'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
+      '#description_display' => 'before',
+      '#open' => FALSE,
     );
-    $form['fieldset_compact_menu']['enabled_services_fieldset']['addthis_enabled_services'] = array(
+    $form['details_compact_menu']['enabled_services_details']['addthis_enabled_services'] = array(
       '#type' => 'checkboxes',
       '#title' => t('Enabled services'),
       '#options' => AddThis::getInstance()->getServices(),
@@ -122,27 +122,26 @@ class AddThisSettingsForm extends ConfigFormBase {
     );
 
     // Additional visual settings.
-    $form['fieldset_compact_menu']['fieldset_additionals'] = array(
-      '#type' => 'fieldset',
+    $form['details_compact_menu']['details_additionals'] = array(
+      '#type' => 'details',
       '#title' => t('Additional configuration'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
+      '#open' => FALSE,
     );
-    $form['fieldset_compact_menu']['fieldset_additionals']['addthis_standard_css_enabled'] = array(
+    $form['details_compact_menu']['details_additionals']['addthis_standard_css_enabled'] = array(
       '#type' => 'checkbox',
       '#title' => t('Use standard AddThis stylesheet'),
       '#description' => t('If not checked, AddThis will not load standard CSS file, allowing you to style everything yourself without incurring the cost of an additional load.'),
       '#default_value' => $config->get('compact_menu.additionals.addthis_standard_css_enabled'),
       '#required' => FALSE,
     );
-    $form['fieldset_compact_menu']['fieldset_additionals']['addthis_508_compliant'] = array(
+    $form['details_compact_menu']['details_additionals']['addthis_508_compliant'] = array(
       '#type' => 'checkbox',
       '#title' => t('508 compliant'),
       '#description' => 'If checked, clicking the AddThis button will open a new window to a page that is keyboard navigable.',
       '#default_value' => $config->get('compact_menu.additionals.addthis_508_compliant'),
       '#required' => FALSE,
     );
-    $form['fieldset_compact_menu']['fieldset_additionals']['addthis_addressbook_enabled'] = array(
+    $form['details_compact_menu']['details_additionals']['addthis_addressbook_enabled'] = array(
       '#type' => 'checkbox',
       '#title' => t('Use addressbook'),
       '#description' => 'If checked, the user will be able import their contacts from popular webmail services when using AddThis\'s email sharing.',
@@ -151,14 +150,14 @@ class AddThisSettingsForm extends ConfigFormBase {
     );
 
     // Excluded Services.
-    $form['fieldset_excluded_services'] = array(
-      '#type' => 'fieldset',
+    $form['details_excluded_services'] = array(
+      '#type' => 'details',
       '#title' => t('Excluded services'),
       '#description' => t('The sharing services you select here will be excluded from all AddThis menus. This applies globally.'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
+      '#description_display' => 'before',
+      '#open' => FALSE,
     );
-    $form['fieldset_excluded_services']['addthis_excluded_services'] = array(
+    $form['details_excluded_services']['addthis_excluded_services'] = array(
       '#type' => 'checkboxes',
       '#title' => t('Excluded services'),
       '#options' => AddThis::getInstance()->getServices(),
@@ -170,22 +169,22 @@ class AddThisSettingsForm extends ConfigFormBase {
     //Analytics settings.
     $profile_id = $config->get('analytics.addthis_profile_id');
     $can_track_clicks = empty($profile_id) ? FALSE : TRUE;
-    $form['fieldset_analytics'] = array(
-      '#type' => 'fieldset',
+    $form['details_analytics'] = array(
+      '#type' => 'details',
       '#title' => t('Analytics and Tracking'),
-      '#collapsible' => TRUE,
-      '#collapsed' => $can_track_clicks ? TRUE : FALSE,
+      '#open' => $can_track_clicks ? TRUE : FALSE,
     );
 
     if (!$can_track_clicks) {
-      $form['fieldset_analytics']['can_track_notice'] = array(
+      $form['details_analytics']['can_track_notice'] = array(
         '#theme' => 'html_tag',
         '#tag' => 'div',
         '#value' => t('For click analytics and statistics you have to provide a ProfileID from <a href="http://www.addthis.com">AddThis.com</a>. Register <a href="https://www.addthis.com/register" targt="_blank">here</a>.'),
         '#attributes' => array('class' => array('messages', 'warning')),
       );
     }
-    $form['fieldset_analytics']['addthis_profile_id'] = array(
+
+    $form['details_analytics']['addthis_profile_id'] = array(
       '#type' => 'textfield',
       '#title' => t('AddThis ProfileID'),
       '#default_value' => $config->get('analytics.addthis_profile_id'),
@@ -193,7 +192,7 @@ class AddThisSettingsForm extends ConfigFormBase {
       '#size' => 25,
       '#description' => t('ProfileID at <a href="http://addthis.com/" target="_blank">AddThis.com</a>. Required for statistics.'),
     );
-    $form['fieldset_analytics']['addthis_clickback_tracking_enabled'] = array(
+    $form['details_analytics']['addthis_clickback_tracking_enabled'] = array(
       '#type' => 'checkbox',
       '#title' => t('Track clickback'),
       '#description' => 'Check to allow AddThis to append a variable to your URLs upon sharing. AddThis will use this to track how many people come back to your content via links shared with AddThis. Highly recommended. Always global.',
@@ -211,19 +210,19 @@ class AddThisSettingsForm extends ConfigFormBase {
     else {
       $rdf_description = t('Check to enable Facebook Like tracking support. Always global.');
     }
-    $form['fieldset_analytics']['title_facebook'] = array(
+    $form['details_analytics']['title_facebook'] = array(
       '#theme' => 'html_tag',
       '#tag' => 'div',
       '#value' => '<b>' . t('Facebook') . '</b>',
     );
-    $form['fieldset_analytics']['facebook_notice'] = array(
+    $form['details_analytics']['facebook_notice'] = array(
       '#theme' => 'html_tag',
       '#tag' => 'p',
       '#value' => $rdf_description,
       '#access' => !$rdf_enabled,
     );
 
-    $form['fieldset_analytics']['addthis_facebook_like_count_support_enabled'] = array(
+    $form['details_analytics']['addthis_facebook_like_count_support_enabled'] = array(
       '#type' => 'checkbox',
       '#title' => t('Enable Facebook Like tracking'),
       '#description' => Xss::filter($rdf_description, array('span')),
@@ -239,26 +238,26 @@ class AddThisSettingsForm extends ConfigFormBase {
     $google_analytics_config = \Drupal::config(google_analytics . settings);
     $google_analytics_account = $google_analytics_config->get('google_analytics_account');
     $is_google_analytics_setup = $can_do_google_social_tracking && isset($google_analytics_account);
-    $form['fieldset_analytics']['google_analytics'] = array(
+    $form['details_analytics']['google_analytics'] = array(
       '#theme' => 'html_tag',
       '#tag' => 'div',
       '#value' => '<b>' . t('Google Analytics') . '</b>',
     );
     if (!$can_do_google_social_tracking) {
-      $form['fieldset_analytics']['can_do_google_analytics'] = array(
+      $form['details_analytics']['can_do_google_analytics'] = array(
         '#theme' => 'html_tag',
         '#tag' => 'p',
         '#value' => '<span class="admin-disabled">' . t('Install/enable the <a href="http://drupal.org/project/google_analytics" target="_blank">Google Analytics</a> module for Social Tracking support.') . '</span>',
       );
     }
     elseif ($can_do_google_social_tracking && !$is_google_analytics_setup) {
-      $form['fieldset_analytics']['can_do_google_analytics'] = array(
+      $form['details_analytics']['can_do_google_analytics'] = array(
         '#theme' => 'html_tag',
         '#tag' => 'p',
         '#value' => '<span class="admin-disabled">' . t('Configure the Google Analytics module correctly with the account code to use this feature.') . '</span>',
       );
     }
-    $form['fieldset_analytics']['addthis_google_analytics_tracking_enabled'] = array(
+    $form['details_analytics']['addthis_google_analytics_tracking_enabled'] = array(
       '#type' => 'checkbox',
       '#title' => t('Track with Google Analytics'),
       '#description' => t('Check to track shares in your Google Analytics account reports (<a href="http://www.addthis.com/help/google-analytics-integration">more info</a>). Always global.'),
@@ -266,7 +265,7 @@ class AddThisSettingsForm extends ConfigFormBase {
       '#required' => FALSE,
       '#disabled' => !$is_google_analytics_setup,
     );
-    $form['fieldset_analytics']['addthis_google_analytics_social_tracking_enabled'] = array(
+    $form['details_analytics']['addthis_google_analytics_social_tracking_enabled'] = array(
       '#type' => 'checkbox',
       '#title' => t('Track with Google Analytics social'),
       '#description' => t('Check to track shares in the new Google Analytics social interaction reports (<a href="http://www.addthis.com/help/google-analytics-integration#social">more info</a>). Always global.'),
@@ -276,26 +275,25 @@ class AddThisSettingsForm extends ConfigFormBase {
     );
 
     // Third party settings.
-    $form['third_party_fieldset'] = array(
-      '#type' => 'fieldset',
+    $form['third_party_details'] = array(
+      '#type' => 'details',
       '#title' => t('Third party settings'),
-      '#collapsible' => TRUE,
-      '#collapsed' => TRUE,
+      '#open' => FALSE,
     );
-    $form['third_party_fieldset']['twitter_service'] = array(
+    $form['third_party_details']['twitter_service'] = array(
       '#type' => 'fieldset',
       '#title' => t('Twitter'),
       '#collapsible' => TRUE,
       '#collapsed' => TRUE,
     );
-    $form['third_party_fieldset']['twitter_service']['addthis_twitter_via'] = array(
+    $form['third_party_details']['twitter_service']['addthis_twitter_via'] = array(
       '#type' => 'textfield',
       '#title' => t('Send via'),
       '#description' => t('When sending a tweet this is the screen name of the user to attribute the Tweet to. (Relates to Tweet Button)'),
       '#default_value' => $config->get('third_party.addthis_twitter_via'),
       '#size' => 15,
     );
-    $form['third_party_fieldset']['twitter_service']['addthis_twitter_template'] = array(
+    $form['third_party_details']['twitter_service']['addthis_twitter_template'] = array(
       '#type' => 'textfield',
       '#title' => t('Template text'),
       '#description' => t('The {{title}} and {{url}} are replaced from the Twitter Button.'),


### PR DESCRIPTION
Note that fieldset has been deprecated in favor of 'details' in d8 form API. I also leveraged the new '#description_display' setting to move the description above the form element where it made sense.
