### PR TITLE
Remove domReady config and always load on domready

### DIFF
--- a/src/AddThisScriptManager.php
+++ b/src/AddThisScriptManager.php
@@ -156,10 +156,6 @@ class AddThisScriptManager {
       $fragment[] = 'async=1';
     }
 
-    if ($adv_config->get('addthis_widget_load_domready')) {
-      $fragment[] = 'domready=1';
-    }
-
 
     $element['#attached']['library'][] = 'addthis/addthis.widget';
     $addThisConfig = $this->getAddThisConfig();

--- a/src/AddThisScriptManager.php
+++ b/src/AddThisScriptManager.php
@@ -156,6 +156,9 @@ class AddThisScriptManager {
       $fragment[] = 'async=1';
     }
 
+    //Always load the script with domready flag.
+    $fragment[] = 'domready=1';
+
 
     $element['#attached']['library'][] = 'addthis/addthis.widget';
     $addThisConfig = $this->getAddThisConfig();

--- a/src/Element/AddThisBasicToolbox.php
+++ b/src/Element/AddThisBasicToolbox.php
@@ -43,6 +43,17 @@ class AddThisBasicToolbox extends RenderElement {
     $services = explode(',', $services);
     $element['services'] = $services;
 
+
+    foreach ($services as $key => $service){
+      $element['services'][$key] = array();
+      $element['services'][$key]['service'] = $service;
+      switch ($service) {
+        case 'linkedin_counter':
+          $element['services'][$key]['attributes'] = new Attribute(array('li:counter' => 'top'));
+          break;
+      }
+    }
+
     return $element;
   }
 

--- a/src/Form/AddThisSettingsAdvancedForm.php
+++ b/src/Form/AddThisSettingsAdvancedForm.php
@@ -93,11 +93,6 @@ class AddThisSettingsAdvancedForm extends ConfigFormBase {
       '#required' => FALSE,
       '#description' => t('AddThis custom configuration code. See format at <a href="http://addthis.com/" target="_blank">AddThis.com</a>'),
     );
-    $form['advanced_settings_details']['addthis_widget_load_domready'] = array(
-      '#type' => 'checkbox',
-      '#title' => t('Load the AddThis resources after the DOM is ready.'),
-      '#default_value' => $config->get('addthis_widget_load_domready'),
-    );
     $form['advanced_settings_details']['addthis_widget_load_async'] = array(
       '#type' => 'checkbox',
       '#title' => t('Initialize asynchronously through addthis.init().'),
@@ -130,7 +125,6 @@ class AddThisSettingsAdvancedForm extends ConfigFormBase {
       ->set('addthis_widget_js_url', $form_state->getValue('addthis_widget_js_url'))
       ->set('addthis_custom_configuration_code_enabled', $form_state->getValue('addthis_custom_configuration_code_enabled'))
       ->set('addthis_custom_configuration_code', $form_state->getValue('addthis_custom_configuration_code'))
-      ->set('addthis_widget_load_domready', $form_state->getValue('addthis_widget_load_domready'))
       ->set('addthis_widget_load_async', $form_state->getValue('addthis_widget_load_async'))
       ->set('addthis_widget_include', $form_state->getValue('addthis_widget_include'))
       ->save();

--- a/templates/addthis-basic-toolbox.html.twig
+++ b/templates/addthis-basic-toolbox.html.twig
@@ -10,6 +10,6 @@
 
 <div class="addthis_toolbox addthis_default_style {{ element['#extra_classes'] }} {{ element['#size'] }} ">
     {% for service in element.services %}
-        <a class="addthis_button_{{ service }}" href="#" ></a>
+        <a class="addthis_button_{{ service.service }}" {{ service.attributes }} href="#" ></a>
     {% endfor %}
 </div>


### PR DESCRIPTION
- Removed advanced config for domready since we always load after the dom is built.
